### PR TITLE
migration to stylistic

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,13 +5,17 @@ module.exports = {
         sourceType: 'module',
         project: './tsconfig.*?.json'
     },
-    plugins: ['@typescript-eslint',
+    plugins: [
+        '@typescript-eslint',
         '@angular-eslint/eslint-plugin',
-        'rxjs'],
+        'rxjs',
+        '@stylistic'
+    ],
     extends: [
         'eslint:recommended',
         'plugin:@typescript-eslint/eslint-recommended',
-        'plugin:@typescript-eslint/recommended'
+        'plugin:@typescript-eslint/recommended',
+        'plugin:@stylistic/disable-legacy'
     ],
     rules: {
         "@angular-eslint/component-class-suffix": ["error",
@@ -157,17 +161,15 @@ module.exports = {
         "no-use-before-define": "off",
         "@typescript-eslint/no-use-before-define": ["error"],
         "@typescript-eslint/prefer-function-type": "error",
-        "quotes": "off",
-        "@typescript-eslint/quotes": [
+        "@stylistic/quotes": [
             "error",
             "single",
             {"allowTemplateLiterals": true}
         ],
-        "semi": "off",
-        "@typescript-eslint/semi": [
+        "@stylistic/semi": [
             "error"
         ],
-        "@typescript-eslint/type-annotation-spacing": "error",
+        "@stylistic/type-annotation-spacing": "error",
         "@typescript-eslint/unified-signatures": "error",
         "no-redeclare": "off",
         "@typescript-eslint/no-redeclare": ["error"],
@@ -175,8 +177,7 @@ module.exports = {
         "@typescript-eslint/no-loss-of-precision": ["error"],
         "default-param-last": "off",
         "@typescript-eslint/default-param-last": ["error"],
-        "brace-style": "off",
-        "@typescript-eslint/brace-style": [
+        "@stylistic/brace-style": [
             "error",
             "1tbs"
         ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@consdata/eslint-config",
-  "version": "0.21.0",
+  "version": "1.0.0",
   "description": "Consdata common ESLint rules",
   "main": "index.js",
   "scripts": {
@@ -15,10 +15,11 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@angular-eslint/eslint-plugin": ">=12.3.1",
-    "@typescript-eslint/eslint-plugin": ">=4.29.1",
-    "@typescript-eslint/parser": ">=4.29.1",
-    "eslint": ">=7.32.0",
-    "eslint-plugin-rxjs": ">=3.3.5"
+    "@angular-eslint/eslint-plugin": ">=19.8.1",
+    "@typescript-eslint/eslint-plugin": ">=8.0.0",
+    "@typescript-eslint/parser": ">=8.0.0",
+    "eslint": ">=8.0.0",
+    "eslint-plugin-rxjs": ">=5.0.0",
+    "@stylistic/eslint-plugin": ">=3.1.0"
   }
 }


### PR DESCRIPTION
-https://eslint.style/guide/migration
-migration to `@stylistic/eslint-plugin`
-update peerDependencies to match eslint >= 8.00
-plugin:@stylistic/disable-legacy
-bump version to 1.0.0